### PR TITLE
Fix process handling when generating translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,14 @@
-## 0.0.1
+## 0.4.1 - 0.4.3
 
-- Initial version.
+- 🐛 Fix bug only generate root
 
-## 0.0.2
+## 0.4.0
 
-- Format code.
+- Added support to Windows
 
-## 0.0.3
+## 0.3.1 - 0.3.5
 
-- Remove unnecessary codes
-
-## 0.1.0
-
-- Apply the new structure for the library
-
-## 0.1.1
-
-- Update README.md
-
-## 0.1.2
-
-- Update README.md
-
-## 0.1.3
-
-- Update README.md
-- Upgrade dependencies
-
-## 0.1.4
-
-- Added flag `--[no-]generate-root` to disable the generation of the root folder
-
-## 0.2.0
-
-- (Breaking changes) Added flag `--[no-]nullable-getter` to enable or disable the nullable getter. By default is true (nullable getters)
+- Improvments erros messages
 
 ## 0.3.0
 
@@ -41,14 +16,39 @@
 - Added flag `--generate-only-module` to generate only the module folder
 - Added option `-generate-module` or `-g` to generate the module folder. This option is only active if the flag `--generate-only-module` is active.
 
-## 0.3.1 - 0.3.5
+## 0.2.0
 
-- Improvments erros messages
+- (Breaking changes) Added flag `--[no-]nullable-getter` to enable or disable the nullable getter. By default is true (nullable getters)
 
-## 0.4.0
+## 0.1.4
 
-- Added support to Windows
+- Added flag `--[no-]generate-root` to disable the generation of the root folder
 
-## 0.4.1 - 0.4.3
+## 0.1.3
 
-- 🐛 Fix bug only generate root
+- Update README.md
+- Upgrade dependencies
+
+## 0.1.2
+
+- Update README.md
+
+## 0.1.1
+
+- Update README.md
+
+## 0.1.0
+
+- Apply the new structure for the library
+
+## 0.0.3
+
+- Remove unnecessary codes
+
+## 0.0.2
+
+- Format code.
+
+## 0.0.1
+
+- Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.0
+
+- Massive refactor splitting the generator into reusable services and utilities while keeping the public API intact.
+- Added duplicate key detection with automatic cleanup of generated outputs before failing.
+- Enhanced CLI feedback with log levels and emoji prefixes for successes, warnings, and errors.
+- Improved error messages for missing/duplicate keys and cleanup failures.
+
 ## 0.4.1 - 0.4.3
 
 - 🐛 Fix bug only generate root

--- a/lib/errors/duplicate_key_exception.dart
+++ b/lib/errors/duplicate_key_exception.dart
@@ -1,0 +1,8 @@
+class DuplicateKeyException implements Exception {
+  DuplicateKeyException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/errors/key_not_found_exception.dart
+++ b/lib/errors/key_not_found_exception.dart
@@ -1,3 +1,8 @@
 class KeyNotFoundException implements Exception {
-  KeyNotFoundException();
+  KeyNotFoundException([this.message = 'Missing localization keys detected.']);
+
+  final String message;
+
+  @override
+  String toString() => message;
 }

--- a/lib/l10m.dart
+++ b/lib/l10m.dart
@@ -1,110 +1,28 @@
-// Função para capitalizar a primeira letra de uma string
-import 'dart:convert';
-import 'dart:io';
-import 'package:path/path.dart' as path;
+import 'dart:async';
 
-import 'package:l10m/errors/key_not_found_exception.dart';
-import 'package:l10m/errors/duplicate_key_exception.dart';
+import 'package:l10m/src/localization_generator.dart';
+import 'package:l10m/src/services/arb_validator.dart';
+import 'package:l10m/src/services/flutter_gen_l10n_runner.dart';
 
-String capitalize(String text) {
-  return text[0].toUpperCase() + text.substring(1);
-}
+export 'src/utils/string_utils.dart'
+    show capitalize, underscoreToCamelCase, camelCaseToUnderscore;
 
-String underscoreToCamelCase(String text) {
-  return text.split('_').map((e) => capitalize(e)).join();
-}
-
-String camelCaseToUnderscore(String text) {
-  return text.replaceAllMapped(RegExp(r'[A-Z]'), (match) {
-    if (match.start == 0) {
-      return match.group(0)!.toLowerCase();
-    } else {
-      return '_${match.group(0)!.toLowerCase()}';
-    }
-  });
-}
+final LocalizationGenerator _generator = LocalizationGenerator();
+const ArbValidator _validator = ArbValidator();
+const FlutterGenL10nRunner _flutterRunner = FlutterGenL10nRunner();
 
 Future<void> generateModulesTranslations({
   required String modulePath,
   required String outputFolder,
   required String templateArbFile,
   required bool nullableGetter,
-}) async {
-  var errors = <String>[];
-  // List of all modules inside the folder
-  final modulePathNormalized = path.normalize(modulePath);
-
-  var dir = Directory(modulePathNormalized);
-  List<FileSystemEntity> features = dir.listSync();
-
-  // Loop through each module
-  for (var feature in features) {
-    // Path to the current module
-    final slash = Platform.isWindows ? '\\' : '/';
-    String featureName = feature.path.split(slash).last;
-    String featurePath = path.normalize('$modulePath/$featureName/l10n');
-
-    String outputPath =
-        path.normalize('$modulePath/$featureName/$outputFolder');
-
-    try {
-      // Verify if the module localization folder exists
-      if (await Directory(featurePath).exists()) {
-        print('🔄 Generating translations for "$featureName" folder');
-        await checkLocalizationKeys(featurePath, templateArbFile,
-            generatedFolderPath: outputPath);
-
-        final flutterPath = await findFlutterExecutable();
-        // Execute flutter gen-l10n for the current module
-        ProcessResult result = await Process.run(flutterPath, [
-          'gen-l10n',
-          '--arb-dir',
-          featurePath,
-          '--output-dir',
-          outputPath,
-          '--no-synthetic-package',
-          '--output-class',
-          '${underscoreToCamelCase(capitalize(featureName))}Localizations',
-          '--template-arb-file',
-          templateArbFile,
-          '--output-localization-file',
-          '${camelCaseToUnderscore(featureName)}_localizations.dart',
-          if (!nullableGetter) '--no-nullable-getter'
-        ]);
-
-        if (result.stdout.toString().isNotEmpty) print(result.stdout);
-        if (result.stderr.toString().isNotEmpty) print(result.stderr);
-
-        if (result.exitCode == 0) {
-          print('✅ Generated translations for "$featureName" folder');
-          continue;
-        }
-
-        throw Exception(
-            '❌ Failed to generate translations for "$featureName" folder: ${result.stderr.toString()} ${result.stdout}');
-      } else {
-        print(
-            '▶▶ Skipped translations for "$featureName" folder because no translations where found in the specified path');
-      }
-    } on KeyNotFoundException catch (e) {
-      errors.add(e.toString());
-      print(
-          '❌ Failed to generate translations because some keys were missing in the files');
-    } on DuplicateKeyException catch (e) {
-      errors.add(e.toString());
-      print(e);
-      print(
-          'Failed to generate translations because duplicate keys were found in the files');
-    } catch (e) {
-      errors.add(e.toString());
-      print(e);
-      print('❌ Failed to generate translations for "$featureName" folder');
-    }
-  }
-
-  if (errors.isNotEmpty) {
-    throw Exception(errors.join('\n'));
-  }
+}) {
+  return _generator.generateModulesTranslations(
+    modulePath: modulePath,
+    outputFolder: outputFolder,
+    templateArbFile: templateArbFile,
+    nullableGetter: nullableGetter,
+  );
 }
 
 Future<void> generateOnlyModuleTranslations({
@@ -113,71 +31,14 @@ Future<void> generateOnlyModuleTranslations({
   required String templateArbFile,
   required bool nullableGetter,
   required String generateModule,
-}) async {
-  var errors = <String>[];
-  // Path to the current module
-  String featurePath = path.normalize('$modulePath/$generateModule/l10n');
-
-  String outputPath =
-      path.normalize('$modulePath/$generateModule/$outputFolder');
-
-  try {
-    // Verify if the module localization folder exists
-    if (await Directory(featurePath).exists()) {
-      print('🔄 Generating translations for "$generateModule" folder');
-      await checkLocalizationKeys(featurePath, templateArbFile,
-          generatedFolderPath: outputPath);
-
-      String flutterPath = await findFlutterExecutable();
-      // Execute flutter gen-l10n for the current module
-      ProcessResult result = await Process.run(flutterPath, [
-        'gen-l10n',
-        '--arb-dir',
-        featurePath,
-        '--output-dir',
-        outputPath,
-        '--no-synthetic-package',
-        '--output-class',
-        '${underscoreToCamelCase(capitalize(generateModule))}Localizations',
-        '--template-arb-file',
-        templateArbFile,
-        '--output-localization-file',
-        '${camelCaseToUnderscore(generateModule)}_localizations.dart',
-        if (!nullableGetter) '--no-nullable-getter'
-      ]);
-
-      if (result.stdout.toString().isNotEmpty) print(result.stdout);
-      if (result.stderr.toString().isNotEmpty) print(result.stderr);
-
-      if (result.exitCode == 0) {
-        print('✅ Generated translations for "$generateModule" folder');
-        return;
-      }
-
-      throw Exception(
-          '❌ Failed to generate translations for "$generateModule": ${result.stderr.toString()} ${result.stdout}');
-    } else {
-      print(
-          '▶▶ Skipped translations for "$generateModule" folder because no translations where found in the specified path');
-    }
-  } on KeyNotFoundException catch (e) {
-    errors.add(e.toString());
-    print(
-        '❌ Failed to generate translations because some keys were missing in the files');
-  } on DuplicateKeyException catch (e) {
-    errors.add(e.toString());
-    print(e);
-    print(
-        'Failed to generate translations because duplicate keys were found in the files');
-  } catch (e) {
-    errors.add(e.toString());
-    print(e);
-    print('❌ Failed to generate translations for "$generateModule" folder');
-  }
-
-  if (errors.isNotEmpty) {
-    throw Exception(errors.join('\n'));
-  }
+}) {
+  return _generator.generateOnlyModuleTranslations(
+    modulePath: modulePath,
+    outputFolder: outputFolder,
+    templateArbFile: templateArbFile,
+    nullableGetter: nullableGetter,
+    generateModule: generateModule,
+  );
 }
 
 Future<void> generateRootTranslations({
@@ -185,243 +46,27 @@ Future<void> generateRootTranslations({
   required String outputFolder,
   required String templateArbFile,
   required bool nullableGetter,
-}) async {
-  var errors = <String>[];
-
-  final outputPath = path.normalize('$rootPath/$outputFolder');
-  final rootPathDir = path.normalize('$rootPath/l10n');
-
-  try {
-    if (await Directory(rootPathDir).exists()) {
-      print('🔄 Generating translations for root folder');
-
-      await checkLocalizationKeys(rootPathDir, templateArbFile,
-          generatedFolderPath: outputPath);
-
-      String flutterPath = await findFlutterExecutable();
-      ProcessResult result = await Process.run(flutterPath, [
-        'gen-l10n',
-        '--arb-dir',
-        rootPathDir,
-        '--output-dir',
-        outputPath,
-        '--no-synthetic-package',
-        '--output-class',
-        'RootLocalizations',
-        '--template-arb-file',
-        templateArbFile,
-        '--output-localization-file',
-        'root_localizations.dart',
-        if (!nullableGetter) '--no-nullable-getter'
-      ]);
-
-      if (result.stdout.toString().isNotEmpty) print(result.stdout);
-      if (result.stderr.toString().isNotEmpty) print(result.stderr);
-
-      if (result.exitCode == 0) {
-        print('✅ Generated translations for root folder');
-        return;
-      }
-
-      throw Exception(
-          '❌ Failed to generate translations for root folder: ${result.stderr.toString()} ${result.stdout}');
-    } else {
-      print(
-          '▶▶ Skipped translations for root folder because no translations where found in the specified path');
-    }
-  } on KeyNotFoundException catch (e) {
-    errors.add(e.toString());
-    print(
-        '❌ Failed to generate translations because some keys were missing in the files');
-  } on DuplicateKeyException catch (e) {
-    errors.add(e.toString());
-    print(e);
-    print(
-        'Failed to generate translations because duplicate keys were found in the files');
-  } catch (e) {
-    errors.add(e.toString());
-    print(e);
-    print('❌ Failed to generate translations for root folder');
-  }
-
-  if (errors.isNotEmpty) {
-    throw Exception(errors.join('\n'));
-  }
+}) {
+  return _generator.generateRootTranslations(
+    rootPath: rootPath,
+    outputFolder: outputFolder,
+    templateArbFile: templateArbFile,
+    nullableGetter: nullableGetter,
+  );
 }
 
-Future<void> checkLocalizationKeys(String folderPath, String templateArbFile,
-    {String? generatedFolderPath}) async {
-  final directory = Directory(folderPath);
-
-  if (!await directory.exists()) {
-    return;
-  }
-
-  final arbFiles = directory
-      .listSync()
-      .whereType<File>()
-      .where((file) => file.path.endsWith('.arb'))
-      .toList();
-
-  if (arbFiles.isEmpty) {
-    return;
-  }
-
-  final templateFile =
-      File(path.normalize(path.join(folderPath, templateArbFile)));
-
-  if (!await templateFile.exists()) {
-    throw Exception(
-        'Template arb file "$templateArbFile" was not found in $folderPath');
-  }
-
-  final templateContent = await templateFile.readAsString();
-  final templateJson = jsonDecode(templateContent) as Map<String, dynamic>;
-  final templateKeys = templateJson.keys.toSet();
-
-  final missingKeys = <String, List<String>>{};
-  final duplicateKeys = <String, Set<String>>{};
-
-  for (final file in arbFiles) {
-    final content = await File(file.path).readAsString();
-    final duplicates = _findDuplicateKeys(content);
-
-    if (duplicates.isNotEmpty) {
-      duplicateKeys[file.path] = duplicates;
-    }
-
-    final json = jsonDecode(content) as Map<String, dynamic>;
-
-    for (final key in templateKeys) {
-      if (!json.containsKey(key)) {
-        missingKeys.putIfAbsent(key, () => []).add(file.path);
-      }
-    }
-  }
-
-  if (duplicateKeys.isNotEmpty) {
-    await _deleteGeneratedLocalization(generatedFolderPath);
-
-    final message = duplicateKeys.entries
-        .map((entry) =>
-            'Duplicate key(s) ${entry.value.join(', ')} found in file ${path.normalize(entry.key)}')
-        .join('\n');
-
-    throw DuplicateKeyException(message);
-  }
-
-  if (missingKeys.isNotEmpty) {
-    final message = missingKeys.entries
-        .map((entry) =>
-            'Key "${entry.key}" was not found in the following files: ${entry.value.map(path.normalize).join(', ')}')
-        .join('\n');
-
-    throw KeyNotFoundException(message);
-  }
+Future<void> checkLocalizationKeys(
+  String folderPath,
+  String templateArbFile, {
+  String? generatedFolderPath,
+}) {
+  return _validator.validate(
+    folderPath,
+    templateArbFile,
+    generatedFolderPath: generatedFolderPath,
+  );
 }
 
-Set<String> _findDuplicateKeys(String content) {
-  final seen = <String>{};
-  final duplicates = <String>{};
-  var index = 0;
-
-  while (index < content.length) {
-    if (content[index] != '"') {
-      index++;
-      continue;
-    }
-
-    index++;
-    final buffer = StringBuffer();
-    var escaped = false;
-
-    while (index < content.length) {
-      final current = content[index];
-
-      if (escaped) {
-        buffer.write(current);
-        escaped = false;
-        index++;
-        continue;
-      }
-
-      if (current == '\\') {
-        escaped = true;
-        index++;
-        continue;
-      }
-
-      if (current == '"') {
-        break;
-      }
-
-      buffer.write(current);
-      index++;
-    }
-
-    if (index >= content.length) {
-      break;
-    }
-
-    final key = buffer.toString();
-    index++;
-
-    while (index < content.length &&
-        (content[index] == ' ' ||
-            content[index] == '\n' ||
-            content[index] == '\r' ||
-            content[index] == '\t')) {
-      index++;
-    }
-
-    if (index < content.length && content[index] == ':') {
-      if (!seen.add(key)) {
-        duplicates.add(key);
-      }
-    }
-  }
-
-  return duplicates;
-}
-
-Future<void> _deleteGeneratedLocalization(String? generatedFolderPath) async {
-  if (generatedFolderPath == null || generatedFolderPath.isEmpty) {
-    return;
-  }
-
-  final normalizedPath = path.normalize(generatedFolderPath);
-  final directory = Directory(normalizedPath);
-
-  try {
-    if (await directory.exists()) {
-      await directory.delete(recursive: true);
-      print(
-          'Removed generated localization files at $normalizedPath due to duplicate keys.');
-    }
-  } catch (e) {
-    print(
-        'Failed to remove generated localization files at $normalizedPath: $e');
-  }
-}
-
-Future<String> findFlutterExecutable() async {
-  // Get the PATH environment variable
-  String? path = Platform.environment['PATH'];
-
-  if (path != null) {
-    // Split the PATH into individual directories
-    List<String> directories = path.split(Platform.isWindows ? ';' : ':');
-
-    // Check each directory for the flutter executable
-    for (String dir in directories) {
-      String flutterPath =
-          Platform.isWindows ? '$dir\\flutter.bat' : '$dir/flutter';
-
-      if (await File(flutterPath).exists()) {
-        return flutterPath;
-      }
-    }
-  }
-
-  return 'flutter';
+Future<String> findFlutterExecutable() {
+  return _flutterRunner.findFlutterExecutable();
 }

--- a/lib/l10m.dart
+++ b/lib/l10m.dart
@@ -70,14 +70,14 @@ Future<void> generateModulesTranslations({
           if (!nullableGetter) '--no-nullable-getter'
         ]);
 
-        if (result.stdout.toString().isEmpty &&
-            result.stderr.toString().isEmpty) {
-          print('✅ Generated translations for "$featureName" folder');
-          return;
-        }
-
         if (result.stdout.toString().isNotEmpty) print(result.stdout);
         if (result.stderr.toString().isNotEmpty) print(result.stderr);
+
+        if (result.exitCode == 0) {
+          print('✅ Generated translations for "$featureName" folder');
+          continue;
+        }
+
         throw Exception(
             '❌ Failed to generate translations for "$featureName" folder: ${result.stderr.toString()} ${result.stdout}');
       } else {
@@ -138,14 +138,14 @@ Future<void> generateOnlyModuleTranslations({
         if (!nullableGetter) '--no-nullable-getter'
       ]);
 
-      if (result.stdout.toString().isEmpty &&
-          result.stderr.toString().isEmpty) {
+      if (result.stdout.toString().isNotEmpty) print(result.stdout);
+      if (result.stderr.toString().isNotEmpty) print(result.stderr);
+
+      if (result.exitCode == 0) {
         print('✅ Generated translations for "$generateModule" folder');
         return;
       }
 
-      if (result.stdout.toString().isNotEmpty) print(result.stdout);
-      if (result.stderr.toString().isNotEmpty) print(result.stderr);
       throw Exception(
           '❌ Failed to generate translations for "$generateModule": ${result.stderr.toString()} ${result.stdout}');
     } else {
@@ -201,14 +201,14 @@ Future<void> generateRootTranslations({
         if (!nullableGetter) '--no-nullable-getter'
       ]);
 
-      if (result.stdout.toString().isEmpty &&
-          result.stderr.toString().isEmpty) {
+      if (result.stdout.toString().isNotEmpty) print(result.stdout);
+      if (result.stderr.toString().isNotEmpty) print(result.stderr);
+
+      if (result.exitCode == 0) {
         print('✅ Generated translations for root folder');
         return;
       }
 
-      if (result.stdout.toString().isNotEmpty) print(result.stdout);
-      if (result.stderr.toString().isNotEmpty) print(result.stderr);
       throw Exception(
           '❌ Failed to generate translations for root folder: ${result.stderr.toString()} ${result.stdout}');
     } else {

--- a/lib/l10m.dart
+++ b/lib/l10m.dart
@@ -284,14 +284,14 @@ Future<void> checkLocalizationKeys(
 }
 
 Future<String> findFlutterExecutable() async {
-  // Obter o PATH do sistema
+  // Get the PATH environment variable
   String? path = Platform.environment['PATH'];
 
   if (path != null) {
-    // Separar o PATH em diretórios individuais
+    // Split the PATH into individual directories
     List<String> directories = path.split(Platform.isWindows ? ';' : ':');
 
-    // Tentar encontrar o executável flutter em cada diretório
+    // Check each directory for the flutter executable
     for (String dir in directories) {
       String flutterPath =
           Platform.isWindows ? '$dir\\flutter.bat' : '$dir/flutter';

--- a/lib/src/localization_generator.dart
+++ b/lib/src/localization_generator.dart
@@ -1,0 +1,203 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'package:l10m/errors/duplicate_key_exception.dart';
+import 'package:l10m/errors/key_not_found_exception.dart';
+import 'package:l10m/src/models/gen_l10n_request.dart';
+import 'package:l10m/src/services/arb_validator.dart';
+import 'package:l10m/src/services/flutter_gen_l10n_runner.dart';
+import 'package:l10m/src/utils/string_utils.dart';
+
+class LocalizationGenerator {
+  LocalizationGenerator({
+    FlutterGenL10nRunner? flutterRunner,
+    ArbValidator? arbValidator,
+  })  : _flutterRunner = flutterRunner ?? const FlutterGenL10nRunner(),
+        _arbValidator = arbValidator ?? const ArbValidator();
+
+  final FlutterGenL10nRunner _flutterRunner;
+  final ArbValidator _arbValidator;
+
+  Future<void> generateModulesTranslations({
+    required String modulePath,
+    required String outputFolder,
+    required String templateArbFile,
+    required bool nullableGetter,
+  }) async {
+    final modulesDirectory = Directory(path.normalize(modulePath));
+    final entries = modulesDirectory
+        .listSync()
+        .whereType<Directory>()
+        .toList(growable: false);
+
+    final flutterExecutable = await _flutterRunner.findFlutterExecutable();
+    final errors = <String>[];
+
+    for (final featureDirectory in entries) {
+      final featureName = path.basename(featureDirectory.path);
+      final arbDirectory = path.join(featureDirectory.path, 'l10n');
+      final outputDirectory = path.join(featureDirectory.path, outputFolder);
+
+      final error = await _generateLocalization(
+        label: '"$featureName"',
+        request: GenL10nRequest(
+          arbDirectory: path.normalize(arbDirectory),
+          outputDirectory: path.normalize(outputDirectory),
+          outputClass:
+              '${underscoreToCamelCase(capitalize(featureName))}Localizations',
+          templateArbFile: templateArbFile,
+          outputLocalizationFile:
+              '${camelCaseToUnderscore(featureName)}_localizations.dart',
+          nullableGetter: nullableGetter,
+        ),
+        flutterExecutable: flutterExecutable,
+      );
+
+      if (error != null) {
+        errors.add(error);
+      }
+    }
+
+    _throwIfAny(errors);
+  }
+
+  Future<void> generateOnlyModuleTranslations({
+    required String modulePath,
+    required String outputFolder,
+    required String templateArbFile,
+    required bool nullableGetter,
+    required String generateModule,
+  }) async {
+    final featureDirectory =
+        Directory(path.normalize(path.join(modulePath, generateModule)));
+
+    final error = await _generateLocalization(
+      label: '"$generateModule"',
+      request: GenL10nRequest(
+        arbDirectory: path.normalize(path.join(featureDirectory.path, 'l10n')),
+        outputDirectory:
+            path.normalize(path.join(featureDirectory.path, outputFolder)),
+        outputClass:
+            '${underscoreToCamelCase(capitalize(generateModule))}Localizations',
+        templateArbFile: templateArbFile,
+        outputLocalizationFile:
+            '${camelCaseToUnderscore(generateModule)}_localizations.dart',
+        nullableGetter: nullableGetter,
+      ),
+      flutterExecutable: await _flutterRunner.findFlutterExecutable(),
+      skipIfMissingArbDir: true,
+    );
+
+    if (error != null) {
+      throw Exception(error);
+    }
+  }
+
+  Future<void> generateRootTranslations({
+    required String rootPath,
+    required String outputFolder,
+    required String templateArbFile,
+    required bool nullableGetter,
+  }) async {
+    final outputDirectory = path.normalize(path.join(rootPath, outputFolder));
+    final arbDirectory = path.normalize(path.join(rootPath, 'l10n'));
+
+    final error = await _generateLocalization(
+      label: 'root',
+      request: GenL10nRequest(
+        arbDirectory: arbDirectory,
+        outputDirectory: outputDirectory,
+        outputClass: 'RootLocalizations',
+        templateArbFile: templateArbFile,
+        outputLocalizationFile: 'root_localizations.dart',
+        nullableGetter: nullableGetter,
+      ),
+      flutterExecutable: await _flutterRunner.findFlutterExecutable(),
+      skipIfMissingArbDir: true,
+    );
+
+    if (error != null) {
+      throw Exception(error);
+    }
+  }
+
+  Future<String?> _generateLocalization({
+    required String label,
+    required GenL10nRequest request,
+    required String flutterExecutable,
+    bool skipIfMissingArbDir = false,
+  }) async {
+    final arbDir = Directory(request.arbDirectory);
+
+    if (!await arbDir.exists()) {
+      if (skipIfMissingArbDir) {
+        _log(
+            'Skipping translations for $label because no .arb files were found.');
+        return null;
+      }
+
+      return 'No translations found in ${request.arbDirectory} for $label';
+    }
+
+    _log('Generating translations for $label ...');
+
+    try {
+      await _arbValidator.validate(
+        request.arbDirectory,
+        request.templateArbFile,
+        generatedFolderPath: request.outputDirectory,
+      );
+
+      final result = await _flutterRunner.runGenL10n(
+        flutterExecutable: flutterExecutable,
+        arguments: request.toArgumentList(),
+      );
+
+      _logProcessStreams(result);
+
+      if (result.exitCode != 0) {
+        throw Exception(result.stderr.toString().trim().isEmpty
+            ? result.stdout
+            : result.stderr);
+      }
+
+      _log('Generated translations for $label.');
+      return null;
+    } on KeyNotFoundException catch (e) {
+      _log('Failed to generate translations for $label: ${e.toString()}');
+      return e.toString();
+    } on DuplicateKeyException catch (e) {
+      _log('Failed to generate translations for $label: ${e.toString()}');
+      return e.toString();
+    } catch (e) {
+      _log('Failed to generate translations for $label: $e');
+      return e.toString();
+    }
+  }
+
+  void _logProcessStreams(ProcessResult result) {
+    final stdoutContent = result.stdout.toString().trim();
+    final stderrContent = result.stderr.toString().trim();
+
+    if (stdoutContent.isNotEmpty) {
+      _log(stdoutContent);
+    }
+
+    if (stderrContent.isNotEmpty) {
+      _log(stderrContent);
+    }
+  }
+
+  void _throwIfAny(List<String> errors) {
+    if (errors.isEmpty) {
+      return;
+    }
+
+    throw Exception(errors.join('\n'));
+  }
+
+  void _log(String message) {
+    print('[l10m] $message');
+  }
+}

--- a/lib/src/models/gen_l10n_request.dart
+++ b/lib/src/models/gen_l10n_request.dart
@@ -1,0 +1,35 @@
+class GenL10nRequest {
+  const GenL10nRequest({
+    required this.arbDirectory,
+    required this.outputDirectory,
+    required this.outputClass,
+    required this.templateArbFile,
+    required this.outputLocalizationFile,
+    required this.nullableGetter,
+  });
+
+  final String arbDirectory;
+  final String outputDirectory;
+  final String outputClass;
+  final String templateArbFile;
+  final String outputLocalizationFile;
+  final bool nullableGetter;
+
+  List<String> toArgumentList() {
+    return [
+      'gen-l10n',
+      '--arb-dir',
+      arbDirectory,
+      '--output-dir',
+      outputDirectory,
+      '--no-synthetic-package',
+      '--output-class',
+      outputClass,
+      '--template-arb-file',
+      templateArbFile,
+      '--output-localization-file',
+      outputLocalizationFile,
+      if (!nullableGetter) '--no-nullable-getter',
+    ];
+  }
+}

--- a/lib/src/services/arb_validator.dart
+++ b/lib/src/services/arb_validator.dart
@@ -160,13 +160,11 @@ class ArbValidator {
       if (await directory.exists()) {
         await directory.delete(recursive: true);
         print(
-          'Removed generated localization files at $normalizedPath due to duplicate keys.',
-        );
+            '[l10m] ⚠️  Removed generated localization files at $normalizedPath due to duplicate keys.');
       }
     } catch (e) {
       print(
-        'Failed to remove generated localization files at $normalizedPath: $e',
-      );
+          '[l10m] ❌ Failed to remove generated localization files at $normalizedPath: $e');
     }
   }
 }

--- a/lib/src/services/arb_validator.dart
+++ b/lib/src/services/arb_validator.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'package:l10m/errors/duplicate_key_exception.dart';
+import 'package:l10m/errors/key_not_found_exception.dart';
+
+class ArbValidator {
+  const ArbValidator();
+
+  Future<void> validate(
+    String folderPath,
+    String templateArbFile, {
+    String? generatedFolderPath,
+  }) async {
+    final directory = Directory(folderPath);
+
+    if (!await directory.exists()) {
+      return;
+    }
+
+    final arbFiles = directory
+        .listSync()
+        .whereType<File>()
+        .where((file) => file.path.endsWith('.arb'))
+        .toList();
+
+    if (arbFiles.isEmpty) {
+      return;
+    }
+
+    final templateFile =
+        File(path.normalize(path.join(folderPath, templateArbFile)));
+
+    if (!await templateFile.exists()) {
+      throw Exception(
+        'Template arb file "$templateArbFile" was not found in $folderPath',
+      );
+    }
+
+    final templateContent = await templateFile.readAsString();
+    final templateJson = jsonDecode(templateContent) as Map<String, dynamic>;
+    final templateKeys = templateJson.keys.toSet();
+
+    final missingKeys = <String, List<String>>{};
+    final duplicateKeys = <String, Set<String>>{};
+
+    for (final file in arbFiles) {
+      final content = await file.readAsString();
+      final duplicates = _findDuplicateKeys(content);
+
+      if (duplicates.isNotEmpty) {
+        duplicateKeys[file.path] = duplicates;
+      }
+
+      final json = jsonDecode(content) as Map<String, dynamic>;
+
+      for (final key in templateKeys) {
+        if (!json.containsKey(key)) {
+          missingKeys.putIfAbsent(key, () => []).add(file.path);
+        }
+      }
+    }
+
+    if (duplicateKeys.isNotEmpty) {
+      await _deleteGeneratedLocalization(generatedFolderPath);
+
+      final message = duplicateKeys.entries
+          .map((entry) =>
+              'Duplicate key(s) ${entry.value.join(', ')} found in file ${path.normalize(entry.key)}')
+          .join('\n');
+
+      throw DuplicateKeyException(message);
+    }
+
+    if (missingKeys.isNotEmpty) {
+      final message = missingKeys.entries
+          .map((entry) =>
+              'Key "${entry.key}" was not found in the following files: ${entry.value.map(path.normalize).join(', ')}')
+          .join('\n');
+
+      throw KeyNotFoundException(message);
+    }
+  }
+
+  Set<String> _findDuplicateKeys(String content) {
+    final seen = <String>{};
+    final duplicates = <String>{};
+    var index = 0;
+
+    while (index < content.length) {
+      if (content[index] != '"') {
+        index++;
+        continue;
+      }
+
+      index++;
+      final buffer = StringBuffer();
+      var escaped = false;
+
+      while (index < content.length) {
+        final current = content[index];
+
+        if (escaped) {
+          buffer.write(current);
+          escaped = false;
+          index++;
+          continue;
+        }
+
+        if (current == '\\') {
+          escaped = true;
+          index++;
+          continue;
+        }
+
+        if (current == '"') {
+          break;
+        }
+
+        buffer.write(current);
+        index++;
+      }
+
+      if (index >= content.length) {
+        break;
+      }
+
+      final key = buffer.toString();
+      index++;
+
+      while (index < content.length &&
+          (content[index] == ' ' ||
+              content[index] == '\n' ||
+              content[index] == '\r' ||
+              content[index] == '\t')) {
+        index++;
+      }
+
+      if (index < content.length && content[index] == ':') {
+        if (!seen.add(key)) {
+          duplicates.add(key);
+        }
+      }
+    }
+
+    return duplicates;
+  }
+
+  Future<void> _deleteGeneratedLocalization(String? generatedFolderPath) async {
+    if (generatedFolderPath == null || generatedFolderPath.isEmpty) {
+      return;
+    }
+
+    final normalizedPath = path.normalize(generatedFolderPath);
+    final directory = Directory(normalizedPath);
+
+    try {
+      if (await directory.exists()) {
+        await directory.delete(recursive: true);
+        print(
+          'Removed generated localization files at $normalizedPath due to duplicate keys.',
+        );
+      }
+    } catch (e) {
+      print(
+        'Failed to remove generated localization files at $normalizedPath: $e',
+      );
+    }
+  }
+}

--- a/lib/src/services/flutter_gen_l10n_runner.dart
+++ b/lib/src/services/flutter_gen_l10n_runner.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+class FlutterGenL10nRunner {
+  const FlutterGenL10nRunner();
+
+  Future<String> findFlutterExecutable() async {
+    final pathVariable = Platform.environment['PATH'];
+
+    if (pathVariable != null) {
+      final directories = pathVariable
+          .split(Platform.isWindows ? ';' : ':')
+          .where((p) => p.isNotEmpty);
+
+      for (final directory in directories) {
+        final flutterPath = Platform.isWindows
+            ? '$directory\\flutter.bat'
+            : '$directory/flutter';
+
+        if (await File(flutterPath).exists()) {
+          return flutterPath;
+        }
+      }
+    }
+
+    return 'flutter';
+  }
+
+  Future<ProcessResult> runGenL10n({
+    required String flutterExecutable,
+    required List<String> arguments,
+  }) async {
+    return Process.run(flutterExecutable, arguments);
+  }
+}

--- a/lib/src/utils/string_utils.dart
+++ b/lib/src/utils/string_utils.dart
@@ -1,0 +1,30 @@
+String capitalize(String text) {
+  if (text.isEmpty) {
+    return text;
+  }
+
+  return text[0].toUpperCase() + text.substring(1);
+}
+
+String underscoreToCamelCase(String text) {
+  if (text.isEmpty) {
+    return text;
+  }
+
+  return text
+      .split('_')
+      .where((segment) => segment.isNotEmpty)
+      .map(capitalize)
+      .join();
+}
+
+String camelCaseToUnderscore(String text) {
+  if (text.isEmpty) {
+    return text;
+  }
+
+  return text.replaceAllMapped(RegExp(r'[A-Z]'), (match) {
+    final letter = match.group(0)!.toLowerCase();
+    return match.start == 0 ? letter : '_$letter';
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: "direct main"
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: "direct dev"
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: c4b5007d91ca4f67256e720cb1b6d704e79a510183a12fa551021f652577dce6
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   pool:
     dependency: transitive
     description:
@@ -309,26 +309,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: d11b55850c68c1f6c0cf00eabded4e66c4043feaf6c0d7ce4a36785137df6331
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.5"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4d070a6bc36c1c4e89f20d353bfd71dc30cdf2bd0e14349090af360a029ab292"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5aaf60d96c4cd00fe7f21594b5ad6a1b699c80a27420f8a837f4d68473ef09e3"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "68.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.1.0"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "21f1d3720fd1c70316399d5e2bccaebb415c434592d778cce8acb967b8578808"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.4.1"
   args:
     dependency: "direct main"
     description:
@@ -150,14 +145,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "12e8a9842b5a7390de7a781ec63d793527582398d16ea26c60fed58833c9ae79"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0-main.0"
   matcher:
     dependency: transitive
     description:
@@ -407,4 +394,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0-256.0.dev <4.0.0"
+  dart: ">=3.3.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: ">=2.14.0 <4.0.0"
 
 dependencies:
-  args: ^2.5.0
-  path: ^1.9.0
+  args: ^2.7.0
+  path: ^1.9.1
 
 dev_dependencies:
   lints: ^4.0.0
-  test: ^1.25.5
-  mocktail: ^1.0.3
-  file: ^7.0.0
+  test: ^1.26.3
+  mocktail: ^1.0.4
+  file: ^7.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: l10m
 description: A library for modular localization in Dart. It allows you to split your localization files into multiple files and load them on demand
-version: 0.4.3
+version: 1.0.0
 repository: https://github.com/augustodia/l10m
 
 environment:


### PR DESCRIPTION
## Summary
- treat flutter gen-l10n success based on the process exit code instead of requiring empty stdout and stderr
- keep generating translations for each module instead of returning after the first successful module

## Testing
- dart test *(fails: dart executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbeaf91fd08330b9ac56f028c976d4